### PR TITLE
Add fullscreen video wall server with cached shell

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,9 +1,8 @@
 const $ = (selector) => document.querySelector(selector);
 const player = $('#player');
-const overlay = $('#overlay');
-const btnStart = $('#btnStart');
 const btnSound = $('#btnSound');
 const btnExit = $('#btnExit');
+const btnFullscreen = $('#btnFullscreen');
 const msg = $('#msg');
 
 let playlist = [];
@@ -84,7 +83,6 @@ async function startPlayback() {
     const videos = await fetchVideos();
     if (!videos.length) {
       showMessage('Nenhum vídeo encontrado na pasta /videos');
-      overlay.style.display = 'flex';
       isStarting = false;
       return;
     }
@@ -93,25 +91,27 @@ async function startPlayback() {
     index = 0;
     setVideo(playlist[index]);
 
-    overlay.style.display = 'none';
-
-    await requestFullscreen().catch(() => {});
-
     const playPromise = player.play();
     if (playPromise && typeof playPromise.catch === 'function') {
       playPromise.catch(() => {});
     }
 
+    await requestFullscreen().catch(() => {});
+
     showMessage('');
   } catch (err) {
-    overlay.style.display = 'flex';
     showMessage(err.message || String(err));
   } finally {
     isStarting = false;
   }
 }
 
-btnStart.addEventListener('click', startPlayback);
+btnFullscreen.addEventListener('click', () => {
+  requestFullscreen().catch(() => {});
+  if (!playlist.length && !isStarting) {
+    startPlayback();
+  }
+});
 
 btnSound.addEventListener('click', () => {
   player.muted = !player.muted;
@@ -142,3 +142,4 @@ player.addEventListener('playing', () => {
 });
 
 updateSoundLabel();
+startPlayback();

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,144 @@
+const $ = (selector) => document.querySelector(selector);
+const player = $('#player');
+const overlay = $('#overlay');
+const btnStart = $('#btnStart');
+const btnSound = $('#btnSound');
+const btnExit = $('#btnExit');
+const msg = $('#msg');
+
+let playlist = [];
+let index = 0;
+let isStarting = false;
+
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+function updateSoundLabel() {
+  btnSound.textContent = `Som: ${player.muted ? 'OFF' : 'ON'}`;
+}
+
+function showMessage(text) {
+  msg.textContent = text || '';
+}
+
+async function fetchVideos() {
+  const response = await fetch('/api/videos', { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error('Não foi possível obter a lista de vídeos');
+  }
+  return response.json();
+}
+
+function requestFullscreen() {
+  const el = document.documentElement;
+  if (el.requestFullscreen) return el.requestFullscreen();
+  if (el.webkitRequestFullscreen) return el.webkitRequestFullscreen();
+  if (el.mozRequestFullScreen) return el.mozRequestFullScreen();
+  if (el.msRequestFullscreen) return el.msRequestFullscreen();
+  return Promise.resolve();
+}
+
+function exitFullscreen() {
+  const doc = document;
+  if (doc.exitFullscreen) return doc.exitFullscreen();
+  if (doc.webkitExitFullscreen) return doc.webkitExitFullscreen();
+  if (doc.mozCancelFullScreen) return doc.mozCancelFullScreen();
+  if (doc.msExitFullscreen) return doc.msExitFullscreen();
+  return Promise.resolve();
+}
+
+function setVideo(filename) {
+  player.src = `/videos/${encodeURIComponent(filename)}`;
+  player.load();
+}
+
+function advancePlaylist() {
+  if (!playlist.length) {
+    return;
+  }
+
+  index = (index + 1) % playlist.length;
+  if (index === 0) {
+    playlist = shuffle(playlist.slice());
+  }
+
+  const nextFile = playlist[index];
+  setVideo(nextFile);
+  player.play().catch(() => {
+    // Falhou novamente, pula para o próximo
+    advancePlaylist();
+  });
+}
+
+async function startPlayback() {
+  if (isStarting) return;
+  isStarting = true;
+  showMessage('Carregando vídeos...');
+
+  try {
+    const videos = await fetchVideos();
+    if (!videos.length) {
+      showMessage('Nenhum vídeo encontrado na pasta /videos');
+      overlay.style.display = 'flex';
+      isStarting = false;
+      return;
+    }
+
+    playlist = shuffle(videos.slice());
+    index = 0;
+    setVideo(playlist[index]);
+
+    overlay.style.display = 'none';
+
+    await requestFullscreen().catch(() => {});
+
+    const playPromise = player.play();
+    if (playPromise && typeof playPromise.catch === 'function') {
+      playPromise.catch(() => {});
+    }
+
+    showMessage('');
+  } catch (err) {
+    overlay.style.display = 'flex';
+    showMessage(err.message || String(err));
+  } finally {
+    isStarting = false;
+  }
+}
+
+btnStart.addEventListener('click', startPlayback);
+
+btnSound.addEventListener('click', () => {
+  player.muted = !player.muted;
+  updateSoundLabel();
+  if (!player.paused) {
+    const playPromise = player.play();
+    if (playPromise && typeof playPromise.catch === 'function') {
+      playPromise.catch(() => {});
+    }
+  }
+});
+
+btnExit.addEventListener('click', () => {
+  exitFullscreen().catch(() => {});
+});
+
+player.addEventListener('ended', () => {
+  advancePlaylist();
+});
+
+player.addEventListener('error', () => {
+  showMessage('Erro ao reproduzir vídeo, avançando...');
+  advancePlaylist();
+});
+
+player.addEventListener('playing', () => {
+  showMessage('');
+});
+
+updateSoundLabel();

--- a/public/index.html
+++ b/public/index.html
@@ -27,31 +27,6 @@
       object-fit: cover;
       background: #000;
     }
-    #overlay {
-      position: absolute;
-      inset: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: rgba(0, 0, 0, 0.65);
-      backdrop-filter: blur(2px);
-      z-index: 3;
-    }
-    #overlay button {
-      font: 600 18px/1.2 system-ui, sans-serif;
-      padding: 14px 24px;
-      color: #fff;
-      background: transparent;
-      border: 2px solid #fff;
-      border-radius: 6px;
-      cursor: pointer;
-      transition: background 0.2s ease, color 0.2s ease;
-    }
-    #overlay button:hover,
-    #overlay button:focus {
-      background: #fff;
-      color: #000;
-    }
     #controls {
       position: absolute;
       left: 16px;
@@ -86,10 +61,6 @@
       text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
     }
     @media (max-width: 600px) {
-      #overlay button {
-        width: 200px;
-        font-size: 16px;
-      }
       .ctrl-btn {
         font-size: 13px;
         padding: 9px 12px;
@@ -100,13 +71,11 @@
 <body>
   <div id="wrap">
     <div id="msg"></div>
-    <video id="player" playsinline muted preload="metadata"></video>
+    <video id="player" playsinline muted preload="metadata" autoplay></video>
     <div id="controls">
+      <button id="btnFullscreen" class="ctrl-btn" type="button">Tela cheia</button>
       <button id="btnSound" class="ctrl-btn" type="button">Som: OFF</button>
       <button id="btnExit" class="ctrl-btn" type="button">Sair FS</button>
-    </div>
-    <div id="overlay">
-      <button id="btnStart" type="button">Clique para iniciar</button>
     </div>
   </div>
   <script src="/app.js" defer></script>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="pt-br">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+  <title>Video Wall</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: #000;
+      height: 100%;
+      overflow: hidden;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: #fff;
+    }
+    #wrap {
+      position: fixed;
+      inset: 0;
+      background: #000;
+    }
+    video {
+      position: absolute;
+      inset: 0;
+      width: 100vw;
+      height: 100vh;
+      object-fit: cover;
+      background: #000;
+    }
+    #overlay {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0, 0, 0, 0.65);
+      backdrop-filter: blur(2px);
+      z-index: 3;
+    }
+    #overlay button {
+      font: 600 18px/1.2 system-ui, sans-serif;
+      padding: 14px 24px;
+      color: #fff;
+      background: transparent;
+      border: 2px solid #fff;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    #overlay button:hover,
+    #overlay button:focus {
+      background: #fff;
+      color: #000;
+    }
+    #controls {
+      position: absolute;
+      left: 16px;
+      bottom: 16px;
+      display: flex;
+      gap: 10px;
+      z-index: 2;
+    }
+    .ctrl-btn {
+      font: 500 14px/1 system-ui, sans-serif;
+      padding: 10px 14px;
+      background: rgba(0, 0, 0, 0.5);
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      border-radius: 4px;
+      color: #fff;
+      cursor: pointer;
+      backdrop-filter: blur(2px);
+      transition: background 0.2s ease;
+    }
+    .ctrl-btn:hover,
+    .ctrl-btn:focus {
+      background: rgba(255, 255, 255, 0.2);
+    }
+    #msg {
+      position: absolute;
+      top: 16px;
+      left: 16px;
+      right: 16px;
+      z-index: 2;
+      color: #ccc;
+      font-size: 14px;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+    }
+    @media (max-width: 600px) {
+      #overlay button {
+        width: 200px;
+        font-size: 16px;
+      }
+      .ctrl-btn {
+        font-size: 13px;
+        padding: 9px 12px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="wrap">
+    <div id="msg"></div>
+    <video id="player" playsinline muted preload="metadata"></video>
+    <div id="controls">
+      <button id="btnSound" class="ctrl-btn" type="button">Som: OFF</button>
+      <button id="btnExit" class="ctrl-btn" type="button">Sair FS</button>
+    </div>
+    <div id="overlay">
+      <button id="btnStart" type="button">Clique para iniciar</button>
+    </div>
+  </div>
+  <script src="/app.js" defer></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js').catch(() => {});
+    }
+  </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,8 @@
       inset: 0;
       background: #000;
     }
-    video {
+    video,
+    img.fullscreen-media {
       position: absolute;
       inset: 0;
       width: 100vw;
@@ -60,6 +61,10 @@
       font-size: 14px;
       text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
     }
+    .ctrl-btn[disabled] {
+      opacity: 0.45;
+      cursor: default;
+    }
     @media (max-width: 600px) {
       .ctrl-btn {
         font-size: 13px;
@@ -72,6 +77,7 @@
   <div id="wrap">
     <div id="msg"></div>
     <video id="player" playsinline muted preload="metadata" autoplay></video>
+    <img id="image" class="fullscreen-media" alt="" hidden />
     <div id="controls">
       <button id="btnFullscreen" class="ctrl-btn" type="button">Tela cheia</button>
       <button id="btnSound" class="ctrl-btn" type="button">Som: OFF</button>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,58 @@
+const CACHE_NAME = 'video-wall-shell-v1';
+const PRECACHE_URLS = ['/', '/app.js'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then((cache) => cache.addAll(PRECACHE_URLS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.map((key) => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+          return null;
+        })
+      )
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  const url = new URL(request.url);
+
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  if (url.pathname.startsWith('/videos/')) {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      const fetchPromise = fetch(request)
+        .then((response) => {
+          if (response && response.ok) {
+            const cloned = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(request, cloned));
+          }
+          return response;
+        })
+        .catch(() => cached);
+
+      return cached || fetchPromise;
+    })
+  );
+});

--- a/server.js
+++ b/server.js
@@ -1,0 +1,220 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { URL } = require('url');
+
+const HOST = process.env.HOST || '0.0.0.0';
+const PORT = parseInt(process.env.PORT || '3000', 10);
+const PUBLIC_DIR = path.join(__dirname, 'public');
+const VIDEOS_DIR = path.join(__dirname, 'videos');
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.ogv': 'video/ogg'
+};
+
+function send(res, status, headers = {}, body) {
+  res.writeHead(status, headers);
+  if (body instanceof fs.ReadStream) {
+    body.pipe(res);
+  } else {
+    res.end(body || '');
+  }
+}
+
+function listVideos() {
+  if (!fs.existsSync(VIDEOS_DIR)) return [];
+  const validExt = new Set(['.mp4', '.webm', '.ogv']);
+  return fs
+    .readdirSync(VIDEOS_DIR)
+    .filter((file) => validExt.has(path.extname(file).toLowerCase()))
+    .sort();
+}
+
+function buildEtag(stat) {
+  return `"${stat.size}-${stat.mtimeMs}"`;
+}
+
+function serveStatic(filePath, req, res) {
+  let stat;
+  try {
+    stat = fs.statSync(filePath);
+    if (stat.isDirectory()) throw new Error('Is directory');
+  } catch (err) {
+    return send(res, 404, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Not found');
+  }
+
+  const ext = path.extname(filePath).toLowerCase();
+  const etag = buildEtag(stat);
+  const lastModified = stat.mtime.toUTCString();
+  const cacheControl = 'public, max-age=604800';
+
+  if (req.headers['if-none-match'] === etag) {
+    return send(res, 304, {
+      ETag: etag,
+      'Last-Modified': lastModified,
+      'Cache-Control': cacheControl
+    });
+  }
+
+  const headers = {
+    'Content-Type': MIME[ext] || 'application/octet-stream',
+    'Content-Length': stat.size,
+    ETag: etag,
+    'Last-Modified': lastModified,
+    'Cache-Control': cacheControl
+  };
+
+  return send(res, 200, headers, fs.createReadStream(filePath));
+}
+
+function serveVideo(filePath, req, res) {
+  let stat;
+  try {
+    stat = fs.statSync(filePath);
+    if (stat.isDirectory()) throw new Error('Is directory');
+  } catch (err) {
+    return send(res, 404, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Video not found');
+  }
+
+  const ext = path.extname(filePath).toLowerCase();
+  const total = stat.size;
+  const etag = buildEtag(stat);
+  const lastModified = stat.mtime.toUTCString();
+
+  const baseHeaders = {
+    'Content-Type': MIME[ext] || 'application/octet-stream',
+    'Accept-Ranges': 'bytes',
+    ETag: etag,
+    'Last-Modified': lastModified,
+    'Cache-Control': 'public, max-age=31536000, immutable'
+  };
+
+  if (req.headers['if-none-match'] === etag) {
+    return send(res, 304, baseHeaders);
+  }
+
+  const range = req.headers.range;
+
+  if (!range) {
+    return send(res, 200, { ...baseHeaders, 'Content-Length': total }, fs.createReadStream(filePath));
+  }
+
+  const matches = range.match(/bytes=(\d*)-(\d*)/);
+  if (!matches) {
+    return send(res, 416, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Bad Range');
+  }
+
+  const startRaw = matches[1];
+  const endRaw = matches[2];
+
+  let start;
+  let end;
+
+  if (startRaw === '' && endRaw === '') {
+    return send(res, 416, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Range Not Satisfiable');
+  }
+
+  if (startRaw === '') {
+    const suffixLength = parseInt(endRaw, 10);
+    if (Number.isNaN(suffixLength)) {
+      return send(res, 416, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Range Not Satisfiable');
+    }
+    end = total - 1;
+    start = Math.max(total - suffixLength, 0);
+  } else {
+    start = parseInt(startRaw, 10);
+    if (Number.isNaN(start)) {
+      return send(res, 416, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Range Not Satisfiable');
+    }
+    if (endRaw === '') {
+      end = total - 1;
+    } else {
+      end = parseInt(endRaw, 10);
+      if (Number.isNaN(end)) {
+        return send(res, 416, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Range Not Satisfiable');
+      }
+    }
+  }
+
+  if (start < 0 || end < 0 || start > end || start >= total) {
+    return send(res, 416, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Range Not Satisfiable');
+  }
+
+  if (end >= total) {
+    end = total - 1;
+  }
+
+  const chunkSize = end - start + 1;
+
+  const headers = {
+    ...baseHeaders,
+    'Content-Range': `bytes ${start}-${end}/${total}`,
+    'Content-Length': chunkSize
+  };
+
+  res.writeHead(206, headers);
+  fs.createReadStream(filePath, { start, end }).pipe(res);
+}
+
+function safeJoin(base, target) {
+  const sanitizedTarget = target.replace(/^[/\\]+/, '');
+  const resolvedPath = path.join(base, sanitizedTarget);
+  if (!resolvedPath.startsWith(base)) {
+    return null;
+  }
+  return resolvedPath;
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const pathname = decodeURIComponent(url.pathname);
+
+  if (pathname === '/healthz') {
+    return send(res, 200, { 'Content-Type': 'text/plain; charset=utf-8' }, 'ok');
+  }
+
+  if (pathname === '/api/videos' && req.method === 'GET') {
+    const files = listVideos();
+    return send(
+      res,
+      200,
+      {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store'
+      },
+      JSON.stringify(files)
+    );
+  }
+
+  if (pathname.startsWith('/videos/')) {
+    const fileName = pathname.replace('/videos/', '');
+    const filePath = safeJoin(VIDEOS_DIR, fileName);
+    if (!filePath) {
+      return send(res, 403, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Forbidden');
+    }
+    return serveVideo(filePath, req, res);
+  }
+
+  const filePath = pathname === '/' ? path.join(PUBLIC_DIR, 'index.html') : safeJoin(PUBLIC_DIR, pathname);
+
+  if (!filePath) {
+    return send(res, 403, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Forbidden');
+  }
+
+  return serveStatic(filePath, req, res);
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`Server running at http://${HOST}:${PORT}`);
+  if (!fs.existsSync(VIDEOS_DIR)) {
+    console.warn('Atenção: crie a pasta ./videos e coloque seus arquivos .mp4/.webm/.ogv');
+  }
+});


### PR DESCRIPTION
## Summary
- implement a pure Node.js server that serves the app shell, video API, and range-enabled video streaming with long-lived caching
- build the fullscreen playback interface with randomised looping playlist, sound controls, and fullscreen handling
- add a service worker to precache the shell while letting browsers manage video caching

## Testing
- node server.js

------
https://chatgpt.com/codex/tasks/task_e_68e5c75485cc832c91ae8cef0e0834e4