### PR TITLE
Adjust existential text pacing and randomness

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -122,11 +122,20 @@ function maybeTriggerPendingAdvance() {
 function pickExistentialText() {
   if (!existentialTexts.length) return null;
   if (!existentialBag.length) {
-    existentialBag = existentialTexts.map((_, index) => index);
-    shuffle(existentialBag);
+    existentialBag = shuffle(existentialTexts.map((_, index) => index));
   }
-  const nextIndex = existentialBag.pop();
+  const nextIndex = existentialBag.splice(Math.floor(Math.random() * existentialBag.length), 1)[0];
   return existentialTexts[nextIndex];
+}
+
+const TYPEWRITER_DELAY = {
+  space: { min: 220, max: 360 },
+  default: { min: 340, max: 520 }
+};
+
+function getTypewriterDelay(char) {
+  const { min, max } = char === ' ' ? TYPEWRITER_DELAY.space : TYPEWRITER_DELAY.default;
+  return min + Math.random() * (max - min);
 }
 
 function renderExistentialTypewriter(text, token) {
@@ -159,7 +168,7 @@ function renderExistentialTypewriter(text, token) {
 
     existentialText.textContent += characters[position];
     const char = characters[position];
-    const delay = char === ' ' ? 120 + Math.random() * 40 : 190 + Math.random() * 110;
+    const delay = getTypewriterDelay(char);
     existentialTypewriterTimer = setTimeout(() => {
       step(position + 1);
     }, delay);


### PR DESCRIPTION
## Summary
- slow down the existential text typewriter effect for a calmer presentation
- randomize selection from the available existential messages to avoid repetition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5ee6e659c832ca68a333360099867