### PR TITLE
Enhance autoimprove observability and life reflections

### DIFF
--- a/autoimprove/plan-runner.js
+++ b/autoimprove/plan-runner.js
@@ -9,23 +9,32 @@ function ensureDirectoryForFile(filePath) {
 
 function applyChange(change) {
   const targetPath = path.join(projectRoot, change.path);
+  console.log('[autoimprove][plan-runner] Aplicando alteração:', change.action, change.path);
   if (change.action === 'delete') {
     if (fs.existsSync(targetPath)) {
       fs.unlinkSync(targetPath);
+      console.log('[autoimprove][plan-runner] Arquivo removido:', change.path);
+    } else {
+      console.log('[autoimprove][plan-runner] Arquivo para remoção não encontrado, ignorando:', change.path);
     }
     return { path: change.path, action: 'delete', description: change.description || '' };
   }
 
   ensureDirectoryForFile(targetPath);
   fs.writeFileSync(targetPath, change.content, 'utf8');
+  console.log('[autoimprove][plan-runner] Arquivo escrito com sucesso:', change.path);
   return { path: change.path, action: 'write', description: change.description || '' };
 }
 
 function applyPlan(plan) {
   const results = [];
   for (const change of plan.changes) {
-    const outcome = applyChange(change);
-    results.push(outcome);
+    try {
+      const outcome = applyChange(change);
+      results.push(outcome);
+    } catch (err) {
+      console.error('[autoimprove][plan-runner] Falha ao aplicar alteração em', change.path, err);
+    }
   }
   return results;
 }

--- a/autoimprove/pm2.js
+++ b/autoimprove/pm2.js
@@ -2,15 +2,27 @@ const { spawn } = require('child_process');
 const { pm2ProcessId, logMonitorDurationMs } = require('./config');
 
 function runCommand(command, args = []) {
+  console.log('[autoimprove][pm2] Executando comando:', command, args.join(' '));
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
     const stdout = [];
     const stderr = [];
 
-    child.stdout.on('data', (chunk) => stdout.push(chunk.toString()));
-    child.stderr.on('data', (chunk) => stderr.push(chunk.toString()));
+    child.stdout.on('data', (chunk) => {
+      const text = chunk.toString();
+      stdout.push(text);
+      console.log('[autoimprove][pm2][stdout]', text.trim());
+    });
+    child.stderr.on('data', (chunk) => {
+      const text = chunk.toString();
+      stderr.push(text);
+      console.error('[autoimprove][pm2][stderr]', text.trim());
+    });
 
-    child.on('error', reject);
+    child.on('error', (error) => {
+      console.error('[autoimprove][pm2] Erro ao executar comando:', command, args.join(' '), error);
+      reject(error);
+    });
     child.on('close', (code) => {
       if (code === 0) {
         resolve({ stdout: stdout.join(''), stderr: stderr.join('') });
@@ -25,30 +37,54 @@ function runCommand(command, args = []) {
 }
 
 async function restartApp() {
-  await runCommand('pm2', ['stop', pm2ProcessId]);
-  await runCommand('pm2', ['start', pm2ProcessId]);
+  try {
+    console.log('[autoimprove][pm2] Parando aplicação com pm2 stop.');
+    await runCommand('pm2', ['stop', pm2ProcessId]);
+  } catch (err) {
+    console.error('[autoimprove][pm2] Não foi possível parar a aplicação. Prosseguindo para restart.', err);
+  }
+
+  try {
+    console.log('[autoimprove][pm2] Reiniciando aplicação com pm2 restart.');
+    await runCommand('pm2', ['restart', pm2ProcessId]);
+  } catch (err) {
+    console.error('[autoimprove][pm2] Falha ao reiniciar a aplicação via pm2 restart:', err);
+    throw err;
+  }
 }
 
 function monitorLogs() {
+  console.log('[autoimprove][pm2] Iniciando captura dos logs via pm2 logs.');
   return new Promise((resolve, reject) => {
     const child = spawn('pm2', ['logs', pm2ProcessId, '--lines', '200'], { stdio: ['ignore', 'pipe', 'pipe'] });
     const chunks = [];
     const errors = [];
 
     const timeout = setTimeout(() => {
+      console.log('[autoimprove][pm2] Tempo de monitoramento atingido. Encerrando leitura de logs.');
       child.kill('SIGTERM');
     }, logMonitorDurationMs);
 
-    child.stdout.on('data', (chunk) => chunks.push(chunk.toString()));
-    child.stderr.on('data', (chunk) => errors.push(chunk.toString()));
+    child.stdout.on('data', (chunk) => {
+      const text = chunk.toString();
+      chunks.push(text);
+      console.log('[autoimprove][pm2][logs]', text.trim());
+    });
+    child.stderr.on('data', (chunk) => {
+      const text = chunk.toString();
+      errors.push(text);
+      console.error('[autoimprove][pm2][logs-err]', text.trim());
+    });
 
     child.on('error', (err) => {
       clearTimeout(timeout);
+      console.error('[autoimprove][pm2] Erro ao monitorar logs:', err);
       reject(err);
     });
 
     child.on('close', () => {
       clearTimeout(timeout);
+      console.log('[autoimprove][pm2] Captura de logs finalizada.');
       resolve({ logs: chunks.join(''), errors: errors.join('') });
     });
   });


### PR DESCRIPTION
## Summary
- expand the autoimprove prompts and cycle execution to emphasize site optimization, philosophical writing, and robust error handling
- harden logging so history/report writes are safe and existential reflections blend life musings with changelog details
- instrument PM2 and plan application routines with detailed console output and resilience around failures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e86aaa2cd4832ca041121a978591dc