### PR TITLE
Update autoimprove endpoint host

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ O repositório inclui um orquestrador que consulta periodicamente um endpoint co
 
 ### Como funciona
 
-1. A cada hora (`AUTOIMPROVE_INTERVAL_MS`), o script `autoimprove/index.js` monta um snapshot textual do projeto (excluindo arquivos binários e diretórios ignorados) e o envia para o endpoint configurado (`AUTOIMPROVE_ENDPOINT`, padrão `http://192.168.31.121:8080/v1/chat/completions`).
+1. A cada hora (`AUTOIMPROVE_INTERVAL_MS`), o script `autoimprove/index.js` monta um snapshot textual do projeto (excluindo arquivos binários e diretórios ignorados) e o envia para o endpoint configurado (`AUTOIMPROVE_ENDPOINT`, padrão `http://192.168.31.29:8000/v1/chat/completions/`).
 2. O modelo precisa responder **somente** com JSON descrevendo arquivos a serem criados/atualizados/removidos, um resumo do que mudou e o foco sugerido para o próximo ciclo.
 3. As alterações são aplicadas imediatamente e registradas em `autoimprove/history.jsonl`, junto com o resumo do ciclo e o motivo.
 4. O servidor Node é reiniciado via `pm2 stop 0` / `pm2 start 0`, e os logs (`pm2 logs 0`) são monitorados por um curto intervalo para detectar erros.
@@ -154,7 +154,7 @@ node autoimprove/index.js "ajuste manual"
 
 | Variável | Descrição | Padrão |
 | --- | --- | --- |
-| `AUTOIMPROVE_ENDPOINT` | URL do endpoint compatível com `/v1/chat/completions`. | `http://192.168.31.121:8080/v1/chat/completions` |
+| `AUTOIMPROVE_ENDPOINT` | URL do endpoint compatível com `/v1/chat/completions`. | `http://192.168.31.29:8000/v1/chat/completions/` |
 | `AUTOIMPROVE_MODEL` | Nome do modelo solicitado ao endpoint. | `gpt-4o-mini` |
 | `AUTOIMPROVE_TEMPERATURE` | Temperatura usada nas requisições. | `0.2` |
 | `AUTOIMPROVE_MAX_TOKENS` | Limite máximo de tokens na resposta. | `2048` |

--- a/autoimprove/config.js
+++ b/autoimprove/config.js
@@ -4,7 +4,7 @@ const projectRoot = path.resolve(__dirname, '..');
 
 module.exports = {
   projectRoot,
-  endpoint: process.env.AUTOIMPROVE_ENDPOINT || 'http://192.168.31.121:8080/v1/chat/completions',
+  endpoint: process.env.AUTOIMPROVE_ENDPOINT || 'http://192.168.31.29:8000/v1/chat/completions/',
   model: process.env.AUTOIMPROVE_MODEL || 'gpt-4o-mini',
   temperature: Number.parseFloat(process.env.AUTOIMPROVE_TEMPERATURE || '0.2'),
   maxTokens: Number.parseInt(process.env.AUTOIMPROVE_MAX_TOKENS || '2048', 10),


### PR DESCRIPTION
## Summary
- point the default autoimprove endpoint to the new host and port
- document the updated endpoint URL in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e86f5cb660832ca4737d4f45c2d939