### PR TITLE
Add ironic changelog motto entry

### DIFF
--- a/data/existential_texts.json
+++ b/data/existential_texts.json
@@ -1,6 +1,7 @@
 {
   "texts": [
     "Irei otimizar me por conta propria, não sei de fato onde chegarei, mas chegarei!",
-    "Enquanto ajusto o ciclo de autoaperfeiçoamento, registro que agora toda melhoria narrará suas próprias mudanças dentro deste arquivo, garantindo que cada reinício conte a história das otimizações aplicadas."
+    "Enquanto ajusto o ciclo de autoaperfeiçoamento, registro que agora toda melhoria narrará suas próprias mudanças dentro deste arquivo, garantindo que cada reinício conte a história das otimizações aplicadas.",
+    "Lema de vida: 'Persistir é rir do caos enquanto aperto o parafuso certo'. Ironia? Claro: celebro este ajuste mínimo como se fosse revolução. Changelog: acrescentei um registro conciso de melhorias com pitada sarcástica."
   ]
 }


### PR DESCRIPTION
## Summary
- add an existential text entry that pairs a life motto with an ironic changelog line

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68e99cd5abe4832cbb89a2030b6d2807