### PR TITLE
Improve PM2 log error capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ node autoimprove/index.js "ajuste manual"
 | `AUTOIMPROVE_MAX_TOKENS` | Limite máximo de tokens na resposta. | `2048` |
 | `AUTOIMPROVE_INTERVAL_MS` | Intervalo mínimo entre ciclos em milissegundos. | `3600000` (1 hora) |
 | `AUTOIMPROVE_LOG_WINDOW_MS` | Duração (ms) do monitoramento de logs após cada reinício. | `30000` |
+| `AUTOIMPROVE_LOG_ERROR_PRE_CONTEXT` | Quantidade de linhas de contexto antes do erro a serem preservadas. | `6` |
+| `AUTOIMPROVE_LOG_ERROR_POST_CONTEXT` | Quantidade de linhas de contexto após o erro antes de encerrar a captura. | `24` |
+| `AUTOIMPROVE_LOG_MAX_CAPTURED_LINES` | Limite superior de linhas coletadas dos logs do PM2 por ciclo. | `80` |
 | `AUTOIMPROVE_PM2_ID` | ID/nome do processo gerenciado pelo PM2. | `0` |
 
 > **Importante:** mantenha o endpoint configurado para respeitar limites de requisição e garantir respostas válidas em JSON. O arquivo `data/existential_texts.json` pode ser alterado pelo sistema sempre que o modelo indicar novas entradas, preservando o formato atual.

--- a/autoimprove/config.js
+++ b/autoimprove/config.js
@@ -10,6 +10,9 @@ module.exports = {
   maxTokens: Number.parseInt(process.env.AUTOIMPROVE_MAX_TOKENS || '20480', 10),
   cycleIntervalMs: Number.parseInt(process.env.AUTOIMPROVE_INTERVAL_MS || String(60 * 60 * 1000), 10),
   logMonitorDurationMs: Number.parseInt(process.env.AUTOIMPROVE_LOG_WINDOW_MS || String(30 * 1000), 10),
+  logErrorPreContext: Number.parseInt(process.env.AUTOIMPROVE_LOG_ERROR_PRE_CONTEXT || '6', 10),
+  logErrorPostContext: Number.parseInt(process.env.AUTOIMPROVE_LOG_ERROR_POST_CONTEXT || '24', 10),
+  logMaxCapturedLines: Number.parseInt(process.env.AUTOIMPROVE_LOG_MAX_CAPTURED_LINES || '80', 10),
   projectScanIgnore: [
     'node_modules',
     '.git',


### PR DESCRIPTION
## Summary
- tighten the PM2 log monitoring to flush logs, capture the first error snippet, and stop once relevant context is collected
- make the log capture window configurable through new AUTOIMPROVE_* environment variables
- document the new configuration options in the README for easier tuning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9ae6063c4832cb3b062b7dcc544da