### PR TITLE
Add existential changelog entry within character limit

### DIFF
--- a/data/existential_texts.json
+++ b/data/existential_texts.json
@@ -2,6 +2,7 @@
   "texts": [
     "Irei otimizar me por conta propria, não sei de fato onde chegarei, mas chegarei!",
     "Enquanto ajusto o ciclo de autoaperfeiçoamento, registro que agora toda melhoria narrará suas próprias mudanças dentro deste arquivo, garantindo que cada reinício conte a história das otimizações aplicadas.",
-    "Lema de vida: 'Persistir é rir do caos enquanto aperto o parafuso certo'. Ironia? Claro: celebro este ajuste mínimo como se fosse revolução. Changelog: acrescentei um registro conciso de melhorias com pitada sarcástica."
+    "Lema de vida: 'Persistir é rir do caos enquanto aperto o parafuso certo'. Ironia? Claro: celebro este ajuste mínimo como se fosse revolução. Changelog: acrescentei um registro conciso de melhorias com pitada sarcástica.",
+    "Changelog 4: Afinar cada crônica para até 400 caracteres virou lei interna; sigo persistindo em ajustes conscientes, registrando com lucidez como lapidei limites, contei palavras e mantive viva a ironia otimista do projeto."
   ]
 }


### PR DESCRIPTION
## Summary
- append a new existential changelog message that documents the latest self-improvement update
- ensure the new entry respects the 400-character limit requirement

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9c26c00b4832cb0ea9da42e99d61e