### PR TITLE
Limit autoimprove reflections to 1000 characters

### DIFF
--- a/autoimprove/logging.js
+++ b/autoimprove/logging.js
@@ -51,6 +51,11 @@ function writeState(state) {
 
 function appendExistentialReflection({ timestamp, summary, changes }) {
   const reflection = buildReflectionText({ timestamp, summary, changes });
+  const MAX_REFLECTION_LENGTH = 1000;
+  const normalizedReflection =
+    reflection.length > MAX_REFLECTION_LENGTH
+      ? reflection.slice(0, MAX_REFLECTION_LENGTH)
+      : reflection;
   let payload = { texts: [] };
 
   try {
@@ -63,7 +68,7 @@ function appendExistentialReflection({ timestamp, summary, changes }) {
     // If the file does not exist or is invalid, start from an empty payload.
   }
 
-  payload.texts = [...(payload.texts || []), reflection];
+  payload.texts = [...(payload.texts || []), normalizedReflection];
   ensureFilePath(existentialTextsFile);
   try {
     fs.writeFileSync(existentialTextsFile, JSON.stringify(payload, null, 2));


### PR DESCRIPTION
## Summary
- enforce a 1000-character cap on auto-generated existential reflections before persisting them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9c2f7d1e4832ca4bc7ef7c2b3f8fe